### PR TITLE
Cg/sc 1079/create a newinviteform specs in permits gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Permits
 
+## 0.3.0 (2024-02-26)
+### Added
+- Added `Permits::Form::NewInvite` - a form object for creating new invites, that checks that the inviter has the necessary permissions to create the invite
+
 ## 0.2.0 (2024-02-26)
 ### Added
 - Added `Permits::Invite` - an invite that can be pre-loaded with permissions and roles for an invitee

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    permits (0.2.0)
+    permits (0.3.0)
       aasm (~> 5.5.0)
       rails (~> 7.1)
       timelines (~> 0.1)

--- a/lib/permits.rb
+++ b/lib/permits.rb
@@ -1,6 +1,7 @@
 require "active_support/configurable"
 require "aasm"
 require "permits/concerns/has_permissions"
+require "permits/forms/new_invite"
 require "permits/invite"
 require "permits/permission"
 require "permits/policy/unauthorized_error"

--- a/lib/permits/forms/new_invite.rb
+++ b/lib/permits/forms/new_invite.rb
@@ -1,0 +1,58 @@
+module Permits
+  module Forms
+    class NewInvite
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveModel::Validations
+
+      attribute :invited_by
+      attribute :email
+      attribute :permission_attributes
+
+      validates :invited_by, presence: true
+      validates :email, presence: true
+
+      def save
+        return false unless valid?
+
+        ActiveRecord::Base.transaction do
+          invite.save!
+          process_permissions if permission_attributes.present?
+        end
+        true
+      end
+
+      def invite
+        @invite ||= Invite.new(
+          invited_by: invited_by,
+          email: email,
+          started_at: Time.current
+        )
+      end
+
+      private
+
+      def process_permissions
+        permission_attributes.each do |resource, permissions|
+          policy_class = if resource.respond_to?(:policy_class)
+            resource.policy_class
+          else
+            ::Permits::Policy::Base
+          end
+          next unless policy_class.authorized?(invited_by, resource, :invite)
+
+          create_permissions(resource, permissions)
+        end
+      end
+
+      def create_permissions(resource, *permissions)
+        permissions.flatten.each do |permits|
+          invite.permissions.find_or_create_by!(
+            resource: resource,
+            permits: permits
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/permits/version.rb
+++ b/lib/permits/version.rb
@@ -1,3 +1,3 @@
 module Permits
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/dummy/app/models/policy/super_user_only_policy.rb
+++ b/spec/dummy/app/models/policy/super_user_only_policy.rb
@@ -1,0 +1,27 @@
+module Policy
+  class SuperUserOnlyPolicy < ::Permits::Policy::Base
+    def super_user?
+      has_action_permissions?(:super_user)
+    end
+
+    def read?
+      has_action_permissions?(:super_user)
+    end
+
+    def edit?
+      has_action_permissions?(:super_user)
+    end
+
+    def create?
+      has_action_permissions?(:super_user)
+    end
+
+    def destroy?
+      has_action_permissions?(:super_user)
+    end
+
+    def invite?
+      has_action_permissions?(:super_user)
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -57,5 +57,4 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_26_134049) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/spec/lib/forms/new_invite_spec.rb
+++ b/spec/lib/forms/new_invite_spec.rb
@@ -1,0 +1,112 @@
+module Permits
+  module Forms
+    describe NewInvite, type: :model do
+      describe "validations" do
+        it { should validate_presence_of(:invited_by) }
+        it { should validate_presence_of(:email) }
+      end
+
+      let(:invited_by) { create(:user) }
+      let(:email) { Faker::Internet.email }
+      let(:permission_attributes) { nil }
+      let!(:form) { described_class.new(invited_by: invited_by, email: email, permission_attributes: permission_attributes) }
+
+      describe "save" do
+        context "without permissions" do
+          it "creates an invite" do
+            expect { form.save }.to change { Invite.count }.by(1)
+            expect(Invite.last.invited_by).to eq(invited_by)
+            expect(Invite.last.email).to eq(email)
+            expect(Invite.last.invitee).to be_nil
+            expect(Invite.last.started_at).to be_within(1.second).of(Time.current)
+          end
+
+          it "does not assign any permissions to the form" do
+            expect { form.save }.to_not change { ::Permits::Permission.count }
+            expect(form.invite.reload.permissions).to be_empty
+          end
+        end
+
+        context "with attached permissions" do
+          let(:group_one) { create(:group) }
+          let(:group_two) { create(:group) }
+
+          let(:permission_attributes) do
+            {
+              group_one => ["read", "edit"],
+              group_two => ["super_user", "destroy"]
+            }
+          end
+
+          context "invited_by has invite permissions for all resources" do
+            let!(:group_one_invite_permissions) { create(:permission, permits: :invite, resource: group_one, owner: invited_by) }
+            let!(:group_two_invite_permissions) { create(:permission, permits: :invite, resource: group_two, owner: invited_by) }
+
+            it "creates permissions for the invite", aggregate_failures: true do
+              expect { form.save }.to change { ::Permits::Permission.count }.by(4)
+              invite = ::Permits::Invite.last
+              expect(invite.permissions.count).to eq(4)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :super_user)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :read)).to eq(true)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :edit)).to eq(true)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :create)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :destroy)).to eq(false)
+
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :super_user)).to eq(true)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :read)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :edit)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :create)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :destroy)).to eq(true)
+            end
+          end
+
+          context "a resource has a custom policy for permission checks" do
+            let!(:group_one_invite_permissions) { create(:permission, permits: :invite, resource: group_one, owner: invited_by) }
+            let!(:group_two_invite_permissions) { create(:permission, permits: :invite, resource: group_two, owner: invited_by) }
+
+            before do
+              allow(group_one).to receive(:policy_class).and_return(
+                ::Policy::SuperUserOnlyPolicy
+              )
+            end
+
+            it "checks permissions against the custom policy" do
+              expect(::Policy::SuperUserOnlyPolicy).to receive(:authorized?).with(invited_by, group_one, :invite).exactly(1).times.and_call_original
+              expect(::Permits::Policy::Base).to receive(:authorized?).with(invited_by, group_two, :invite).exactly(1).times.and_call_original
+
+              form.save
+            end
+          end
+
+          context "invited_by has invite permissions for some resources" do
+            let!(:group_one_invite_permissions) { create(:permission, permits: :invite, resource: group_one, owner: invited_by) }
+
+            it "creates permissions for the invite where it can", aggregate_failures: true do
+              expect { form.save }.to change { ::Permits::Permission.count }.by(2)
+              invite = ::Permits::Invite.last
+              expect(invite.permissions.count).to eq(2)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :super_user)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :read)).to eq(true)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :edit)).to eq(true)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :create)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_one, :destroy)).to eq(false)
+
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :super_user)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :read)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :edit)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :create)).to eq(false)
+              expect(::Permits::Policy::Base.authorized?(invite, group_two, :destroy)).to eq(false)
+            end
+          end
+
+          context "invited_by has no invite permissions" do
+            it "does not create any permissions for the invite" do
+              expect { form.save }.to_not change { ::Permits::Permission.count }
+              expect(form.invite.reload.permissions).to be_empty
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,5 +45,5 @@ Shoulda::Matchers.configure do |config|
 end
 
 Permits.configure do |config|
-  config.permits = %i[super_user read edit create destroy]
+  config.permits = %i[super_user read edit create destroy invite]
 end


### PR DESCRIPTION
- Added `Permits::Form::NewInvite` to create a simple form interface for creating an invite with requested permissions