### PR TITLE
Normalize the email field on Permits::Invites to downcase

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "GitHooks.hooksDirectory": "/Users/craiggilchrist/dev/project-container/local_gems/permits/.git/hooks"
+  "GitHooks.hooksDirectory": "/Users/craiggilchrist/dev/permits/.git/hooks"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Permits
 
+## 1.1.2 (2024-06-14)
+- normalize email field on Permits::Invites
+
 ## 1.1.1 (2024-05-28)
 - Update `timelines` gem from `0.1.3` to `0.3.0`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    permits (1.1.1)
+    permits (1.1.2)
       aasm (~> 5.5.0)
       rails (~> 7.1)
       timelines (~> 0.3.0)

--- a/lib/permits/invite.rb
+++ b/lib/permits/invite.rb
@@ -4,6 +4,8 @@ module Permits
   class Invite < ActiveRecord::Base
     self.table_name = "permits_invites"
 
+    normalizes :email, with: -> email { email.strip.downcase }
+
     include ::AASM
     include ::Timelines::Ephemeral
     include ::Permits::HasPermissions

--- a/lib/permits/version.rb
+++ b/lib/permits/version.rb
@@ -1,3 +1,3 @@
 module Permits
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/spec/lib/invite_spec.rb
+++ b/spec/lib/invite_spec.rb
@@ -15,6 +15,11 @@ module Permits
       it "has a valid factory" do
         expect(build(:invite)).to be_valid
       end
+
+      it "normalizes the email" do
+        invite = create(:invite, email: "Case.Sensitive.Email@Address.Com")
+        expect(invite.email).to eq("case.sensitive.email@address.com")
+      end
     end
 
     describe "state machine" do


### PR DESCRIPTION
Add a normalize to Permits::Invites#email to ensure they are stripped of whitespace and downcased.
Bump versin to 1.1.2