### PR TITLE
additional optional params for `has_action_permissions?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Permits
 
+## 1.1.4 (2024-08-06)
+- Added optional `for_resource_type` and `for_resource_id` params for `::Permits::Policy::Base#has_action_permissions?`, to allow specifying params (potentially avoiding a database hit if the querying code already knows what a relation type/id may be)
+- Moved the `::Permits::Policy::Base#has_action_permissions?` out of the `private` space into the public interface
+
 ## 1.1.3 (2024-08-06)
 - Change Timelines requirement from `~> 0.3.0` to `>= 0.3.0` to improve compatibility with other gems
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    permits (1.1.3)
+    permits (1.1.4)
       aasm (~> 5.5.0)
       rails (~> 7.1)
       timelines (>= 0.3.0)

--- a/lib/permits/policy/base.rb
+++ b/lib/permits/policy/base.rb
@@ -35,13 +35,17 @@ module Permits
         end
       end
 
-      private
-
-      def has_action_permissions?(action, for_resource: resource)
+      def has_action_permissions?(action, for_resource: resource, for_resource_type: nil, for_resource_id: nil)
         return false unless owner_permissions.respond_to?("permits_#{action}")
 
-        owner_permissions.send("permits_#{action}").where(resource: for_resource).exists?
+        if for_resource_type && for_resource_id
+          owner_permissions.send("permits_#{action}").where(resource_type: for_resource_type, resource_id: for_resource_id).exists?
+        else
+          owner_permissions.send("permits_#{action}").where(resource: for_resource).exists?
+        end
       end
+
+      private
 
       def owner_permissions
         @owner_permissions ||= ::Permits::Permission.active.where(owner: owner).includes(:resource)

--- a/lib/permits/version.rb
+++ b/lib/permits/version.rb
@@ -1,3 +1,3 @@
 module Permits
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end

--- a/spec/lib/policy/base_spec.rb
+++ b/spec/lib/policy/base_spec.rb
@@ -112,6 +112,26 @@ module Permits
             it { is_expected.to be false }
           end
         end
+
+        describe "has_action_permissions?" do
+          context "default behavior (checks resource)" do
+            let(:subject) { policy.has_action_permissions?(check_level) }
+
+            it { is_expected.to be true }
+          end
+
+          context "when passed a for_resource param" do
+            let(:subject) { policy.has_action_permissions?(check_level, for_resource: resource) }
+
+            it { is_expected.to be true }
+          end
+
+          context "when passed a for_resource_type and for_resource_id param" do
+            let(:subject) { policy.has_action_permissions?(check_level, for_resource_type: resource.class.name, for_resource_id: resource.id) }
+
+            it { is_expected.to be true }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- Added optional `for_resource_type` and `for_resource_id` params for `::Permits::Policy::Base#has_action_permissions?`, to allow specifying params (potentially avoiding a database hit if the querying code already knows what a relation type/id may be)
- Moved the `::Permits::Policy::Base#has_action_permissions?` out of the `private` space into the public interface