### PR TITLE
Add some other indices to Permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Permits
 
+## 1.1.5 (2024-11-27)
+- Added indexes on `started_at`, `ended_at` (used by `Timelines::Ephemeral` for 'active?' checks), and `permits` for `Permits::Permission`
+
 ## 1.1.4 (2024-11-20)
 - Added optional `for_resource_type` and `for_resource_id` params for `::Permits::Policy::Base#has_action_permissions?`, to allow specifying params (potentially avoiding a database hit if the querying code already knows what a relation type/id may be)
 - Moved the `::Permits::Policy::Base#has_action_permissions?` out of the `private` space into the public interface

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    permits (1.1.4)
+    permits (1.1.5)
       aasm (~> 5.5.0)
       rails (~> 7.1)
       timelines (>= 0.3.0)

--- a/lib/generators/permits/install/templates/create_permits_permissions.rb
+++ b/lib/generators/permits/install/templates/create_permits_permissions.rb
@@ -12,5 +12,8 @@ class CreatePermitsPermissions < ActiveRecord::Migration[7.1]
 
     add_index :permits_permissions, [:owner_id, :owner_type]
     add_index :permits_permissions, [:resource_id, :resource_type]
+    add_index :permits_permissions, :started_at
+    add_index :permits_permissions, :ended_at
+    add_index :permits_permissions, :permits
   end
 end

--- a/lib/permits/version.rb
+++ b/lib/permits/version.rb
@@ -1,3 +1,3 @@
 module Permits
-  VERSION = "1.1.4"
+  VERSION = "1.1.5"
 end

--- a/spec/dummy/db/migrate/20231009133315_create_permit_permissions.rb
+++ b/spec/dummy/db/migrate/20231009133315_create_permit_permissions.rb
@@ -12,5 +12,8 @@ class CreatePermitPermissions < ActiveRecord::Migration[7.1]
 
     add_index :permits_permissions, [:owner_id, :owner_type]
     add_index :permits_permissions, [:resource_id, :resource_type]
+    add_index :permits_permissions, :started_at
+    add_index :permits_permissions, :ended_at
+    add_index :permits_permissions, :permits
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -46,10 +46,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_131534) do
     t.datetime "ended_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["ended_at"], name: "index_permits_permissions_on_ended_at"
     t.index ["owner_id", "owner_type"], name: "index_permits_permissions_on_owner_id_and_owner_type"
     t.index ["owner_type", "owner_id"], name: "index_permits_permissions_on_owner"
+    t.index ["permits"], name: "index_permits_permissions_on_permits"
     t.index ["resource_id", "resource_type"], name: "index_permits_permissions_on_resource_id_and_resource_type"
     t.index ["resource_type", "resource_id"], name: "index_permits_permissions_on_resource"
+    t.index ["started_at"], name: "index_permits_permissions_on_started_at"
   end
 
   create_table "timelines_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Added indexes on `started_at`, `ended_at` (used by `Timelines::Ephemeral` for 'active?' checks), and `permits` for `Permits::Permission`